### PR TITLE
Use NetworkImageFactory service to create network images.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 	<properties>
 		<bundle.symbolicName>org.cytoscape.mcode</bundle.symbolicName>
 		<bundle.namespace>ca.utoronto.tdccbr.mcode.internal</bundle.namespace>
-		<cytoscape.api.version>3.8.0</cytoscape.api.version>
-		<cytoscape.impl.version>3.8.0</cytoscape.impl.version>
+		<cytoscape.api.version>3.9.0-SNAPSHOT</cytoscape.api.version>
+		<cytoscape.impl.version>3.9.0-SNAPSHOT</cytoscape.impl.version>
 		<maven.build.timestamp.format>MMMM yyyy</maven.build.timestamp.format>
 		<buildDate>${maven.build.timestamp}</buildDate>
 	</properties>
@@ -17,7 +17,7 @@
 	<artifactId>mcode-app</artifactId>
 	<name>MCODE</name>
 	<packaging>bundle</packaging>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 
 	<build>
 		<resources>

--- a/src/main/java/ca/utoronto/tdccbr/mcode/internal/CyActivator.java
+++ b/src/main/java/ca/utoronto/tdccbr/mcode/internal/CyActivator.java
@@ -1,13 +1,6 @@
 package ca.utoronto.tdccbr.mcode.internal;
 
-import static org.cytoscape.work.ServiceProperties.COMMAND;
-import static org.cytoscape.work.ServiceProperties.COMMAND_DESCRIPTION;
-import static org.cytoscape.work.ServiceProperties.COMMAND_EXAMPLE_JSON;
-import static org.cytoscape.work.ServiceProperties.COMMAND_LONG_DESCRIPTION;
-import static org.cytoscape.work.ServiceProperties.COMMAND_NAMESPACE;
-import static org.cytoscape.work.ServiceProperties.COMMAND_SUPPORTS_JSON;
-import static org.cytoscape.work.ServiceProperties.PREFERRED_MENU;
-import static org.cytoscape.work.ServiceProperties.TITLE;
+import static org.cytoscape.work.ServiceProperties.*;
 
 import java.util.Properties;
 
@@ -29,7 +22,6 @@ import org.cytoscape.service.util.CyServiceRegistrar;
 import org.cytoscape.util.swing.FileUtil;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.view.model.CyNetworkViewManager;
-import org.cytoscape.view.presentation.RenderingEngineFactory;
 import org.cytoscape.view.vizmap.VisualMappingFunctionFactory;
 import org.cytoscape.view.vizmap.VisualMappingManager;
 import org.cytoscape.view.vizmap.VisualStyleFactory;
@@ -89,7 +81,6 @@ public class CyActivator extends AbstractCyActivator {
 	private MainPanelMediator mainPanelMediator;
 	
 	@Override
-	@SuppressWarnings("unchecked")
 	public void start(BundleContext bc) {
 		registrar = getService(bc, CyServiceRegistrar.class);
 		
@@ -101,7 +92,6 @@ public class CyActivator extends AbstractCyActivator {
 		var rootNetworkMgr = getService(bc, CyRootNetworkManager.class);
 		
 		var swingApp = getService(bc, CySwingApplication.class);
-		var dingRenderingEngineFactory = getService(bc, RenderingEngineFactory.class, "(id=ding)");
 		
 		var visualStyleFactory = getService(bc, VisualStyleFactory.class);
 		var visualMappingMgr = getService(bc, VisualMappingManager.class);
@@ -110,7 +100,7 @@ public class CyActivator extends AbstractCyActivator {
 		
 		var fileUtil = getService(bc, FileUtil.class);
 		
-		mcodeUtil = new MCODEUtil(dingRenderingEngineFactory, netViewFactory, rootNetworkMgr,
+		mcodeUtil = new MCODEUtil(netViewFactory, rootNetworkMgr,
 								  appMgr, netMgr, netViewMgr, visualStyleFactory,
 								  visualMappingMgr, swingApp, discreteMappingFactory,
 								  continuousMappingFactory, fileUtil);

--- a/src/main/java/ca/utoronto/tdccbr/mcode/internal/util/MCODEUtil.java
+++ b/src/main/java/ca/utoronto/tdccbr/mcode/internal/util/MCODEUtil.java
@@ -1,18 +1,6 @@
 package ca.utoronto.tdccbr.mcode.internal.util;
 
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_SELECTED_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_STROKE_SELECTED_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_STROKE_UNSELECTED_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_UNSELECTED_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_WIDTH;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_BORDER_WIDTH;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_FILL_COLOR;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_HEIGHT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_PAINT;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_SHAPE;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_SIZE;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_WIDTH;
+import static org.cytoscape.view.presentation.property.BasicVisualLexicon.*;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -37,7 +25,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 
 import org.cytoscape.application.CyApplicationManager;
 import org.cytoscape.application.NetworkViewRenderer;
@@ -57,8 +44,6 @@ import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.view.model.CyNetworkViewManager;
 import org.cytoscape.view.model.VisualProperty;
-import org.cytoscape.view.presentation.RenderingEngine;
-import org.cytoscape.view.presentation.RenderingEngineFactory;
 import org.cytoscape.view.presentation.property.BasicVisualLexicon;
 import org.cytoscape.view.presentation.property.NodeShapeVisualProperty;
 import org.cytoscape.view.presentation.property.values.NodeShape;
@@ -144,7 +129,7 @@ public class MCODEUtil {
 	private static final Color NODE_MIN_COLOR = Color.BLACK;
 	private static final Color NODE_MAX_COLOR = Color.RED;
 
-	private final RenderingEngineFactory<CyNetwork> renderingEngineFactory;
+//	private final RenderingEngineFactory<CyNetwork> renderingEngineFactory;
 	private final CyNetworkViewFactory networkViewFactory;
 	private final CyRootNetworkManager rootNetworkMgr;
 	private final CyApplicationManager applicationMgr;
@@ -170,7 +155,6 @@ public class MCODEUtil {
 	private static final Logger logger = LoggerFactory.getLogger(MCODEUtil.class);
 	
 	public MCODEUtil(
-			RenderingEngineFactory<CyNetwork> renderingEngineFactory,
 			CyNetworkViewFactory networkViewFactory,
 			CyRootNetworkManager rootNetworkMgr,
 			CyApplicationManager applicationMgr,
@@ -183,7 +167,6 @@ public class MCODEUtil {
 			VisualMappingFunctionFactory continuousMappingFactory,
 			FileUtil fileUtil
 	) {
-		this.renderingEngineFactory = renderingEngineFactory;
 		this.networkViewFactory = networkViewFactory;
 		this.rootNetworkMgr = rootNetworkMgr;
 		this.applicationMgr = applicationMgr;
@@ -366,9 +349,6 @@ public class MCODEUtil {
 		return view;
 	}
 	
-	public RenderingEngine<CyNetwork> createRenderingEngine(JPanel panel, CyNetworkView view) {
-		return renderingEngineFactory.createRenderingEngine(panel, view);
-	}
 
 	public void displayNetworkView(CyNetworkView view) {
 		networkMgr.addNetwork(view.getModel());

--- a/src/main/java/ca/utoronto/tdccbr/mcode/internal/view/MainPanelMediator.java
+++ b/src/main/java/ca/utoronto/tdccbr/mcode/internal/view/MainPanelMediator.java
@@ -6,16 +6,13 @@ import static org.cytoscape.util.swing.LookAndFeelUtil.createOkCancelPanel;
 import static org.cytoscape.util.swing.LookAndFeelUtil.isMac;
 import static org.cytoscape.util.swing.LookAndFeelUtil.makeSmall;
 import static org.cytoscape.util.swing.LookAndFeelUtil.setDefaultOkCancelKeyStrokes;
-import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NETWORK_BACKGROUND_PAINT;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NETWORK_HEIGHT;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NETWORK_WIDTH;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_X_LOCATION;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.NODE_Y_LOCATION;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dialog.ModalityType;
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -38,7 +35,6 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JSlider;
 import javax.swing.SwingUtilities;
@@ -62,6 +58,7 @@ import org.cytoscape.task.visualize.ApplyVisualStyleTaskFactory;
 import org.cytoscape.util.swing.IconManager;
 import org.cytoscape.util.swing.TextIcon;
 import org.cytoscape.view.model.CyNetworkViewManager;
+import org.cytoscape.view.presentation.NetworkImageFactory;
 import org.cytoscape.view.vizmap.VisualMappingManager;
 import org.cytoscape.view.vizmap.VisualStyle;
 import org.cytoscape.work.AbstractTask;
@@ -664,30 +661,15 @@ public class MainPanelMediator implements NetworkAboutToBeDestroyedListener, Set
 				layouter.doLayout();
 			}
 			
-			invokeOnEDT(() -> {
-				try {
-					var panel = new JPanel();
-					var size = new Dimension(width, height);
-					panel.setPreferredSize(size);
-					panel.setSize(size);
-					panel.setMinimumSize(size);
-					panel.setMaximumSize(size);
-					panel.setBackground((Color) style.getDefaultValue(NETWORK_BACKGROUND_PAINT));
-		
-					var re = mcodeUtil.createRenderingEngine(panel, clusterView);
-					style.apply(clusterView);
-					clusterView.updateView();
-					clusterView.fitContent();
-		
-					if (!clusterView.getNodeViews().isEmpty())
-						cluster.setView(clusterView);
-					
-					var image = re.createImage(width, height);
-					cluster.setImage(image);
-				} catch (Exception ex) {
-					logger.error("Cannot update cluster image.", ex);
-				}
-			});
+			
+			style.apply(clusterView);
+			
+			var networkImageFactory = registrar.getService(NetworkImageFactory.class);
+			var image = networkImageFactory.createImage(clusterView, width, height);
+			
+			cluster.setView(clusterView);
+			cluster.setImage(image);
+			
 		} catch (Exception ex) {
 			logger.error("Cannot create cluster image.", ex);
 		}

--- a/src/test/java/org/cytoscape/mcode/internal/model/MCODEAlgorithmTest.java
+++ b/src/test/java/org/cytoscape/mcode/internal/model/MCODEAlgorithmTest.java
@@ -17,7 +17,6 @@ import org.cytoscape.model.subnetwork.CySubNetwork;
 import org.cytoscape.util.swing.FileUtil;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.view.model.CyNetworkViewManager;
-import org.cytoscape.view.presentation.RenderingEngineFactory;
 import org.cytoscape.view.vizmap.VisualMappingFunctionFactory;
 import org.cytoscape.view.vizmap.VisualMappingManager;
 import org.cytoscape.view.vizmap.VisualStyleFactory;
@@ -74,7 +73,6 @@ public class MCODEAlgorithmTest extends AbstractMCODETest {
 
 	CyNetwork networkSmall;
 	
-	@Mock RenderingEngineFactory<CyNetwork> rendererFactory;
 	@Mock CyRootNetworkManager rootNetMgr;
 	@Mock CyApplicationManager appMgr;
 	@Mock CyNetworkManager netMgr;
@@ -96,7 +94,7 @@ public class MCODEAlgorithmTest extends AbstractMCODETest {
 		rootNetMgr = netViewTestSupport.getRootNetworkFactory();
 		netViewFactory = netViewTestSupport.getNetworkViewFactory();
 		
-		mcodeUtil = new MCODEUtil(rendererFactory, netViewFactory, rootNetMgr, appMgr, netMgr, netViewMgr,
+		mcodeUtil = new MCODEUtil(netViewFactory, rootNetMgr, appMgr, netMgr, netViewMgr,
 				styleFactory, vmMgr, swingApp, vmfFactory, vmfFactory, fileUtil);
 		resultsMgr = new MCODEResultsManager(mcodeUtil);
 //		networkSmall = Cytoscape.createNetworkFromFile("testData" + File.separator + "smallTest.sif");

--- a/src/test/java/org/cytoscape/mcode/internal/util/MCODEUtilTest.java
+++ b/src/test/java/org/cytoscape/mcode/internal/util/MCODEUtilTest.java
@@ -15,7 +15,6 @@ import org.cytoscape.model.subnetwork.CyRootNetworkManager;
 import org.cytoscape.util.swing.FileUtil;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.view.model.CyNetworkViewManager;
-import org.cytoscape.view.presentation.RenderingEngineFactory;
 import org.cytoscape.view.vizmap.VisualMappingFunctionFactory;
 import org.cytoscape.view.vizmap.VisualMappingManager;
 import org.cytoscape.view.vizmap.VisualStyleFactory;
@@ -72,7 +71,6 @@ import ca.utoronto.tdccbr.mcode.internal.util.MCODEUtil;
 public class MCODEUtilTest extends AbstractMCODETest {
 
 	CyNetwork networkSmall;
-	@Mock RenderingEngineFactory<CyNetwork> rendererFactory;
 	@Mock CyRootNetworkManager rootNetMgr;
 	@Mock CyApplicationManager appMgr;
 	@Mock CyNetworkManager netMgr;
@@ -91,7 +89,7 @@ public class MCODEUtilTest extends AbstractMCODETest {
 		rootNetMgr = netViewTestSupport.getRootNetworkFactory();
 		netViewFactory = netViewTestSupport.getNetworkViewFactory();
 		
-		mcodeUtil = new MCODEUtil(rendererFactory, netViewFactory, rootNetMgr, appMgr, netMgr, netViewMgr,
+		mcodeUtil = new MCODEUtil(netViewFactory, rootNetMgr, appMgr, netMgr, netViewMgr,
 				styleFactory, vmMgr, swingApp, vmfFactory, vmfFactory, fileUtil);
 		resultsMgr = new MCODEResultsManager(mcodeUtil);
 	}


### PR DESCRIPTION
This branch shows how the new NetworkImageFactory service, to be introduced in Cytoscape 3.9, can be used by MCODE. 